### PR TITLE
New allocation strategy of disk space

### DIFF
--- a/kickstart.cfg.pkrtpl.hcl
+++ b/kickstart.cfg.pkrtpl.hcl
@@ -30,11 +30,11 @@ clearpart --all --initlabel
 part /boot --fstype=xfs --size=512 --label=boot
 part pv.01 --grow --size=1
 volgroup vg.01 --pesize=4096 pv.01
-logvol / --fstype=xfs --name=root --vgname=vg.01 --size=10240 --grow
-logvol /home --fstype=xfs --name=home --vgname=vg.01 --size=1024 --fsoptions="nodev"
+logvol / --fstype=xfs --name=root --vgname=vg.01 --size=10240
+logvol /home --fstype=xfs --name=home --vgname=vg.01 --size=4096 --fsoptions="nodev"
 logvol /tmp --fstype=xfs --name=tmp --vgname=vg.01 --size=1024 --fsoptions="nodev,noexec,nosuid"
 logvol /var/tmp --fstype=xfs --name=var_tmp --vgname=vg.01 --size=1024 --fsoptions="nodev,nosuid,noexec"
-logvol /var --fstype=xfs --name=var --vgname=vg.01 --size=3072
+logvol /var --fstype=xfs --name=var --vgname=vg.01 --size=4096
 logvol /var/log --fstype=xfs --name=var_log --vgname=vg.01 --size=1024
 logvol /var/log/audit --fstype=xfs --name=var_log_audit --vgname=vg.01 --size=512
 logvol swap --name=swap --vgname=vg.01 --size=1024

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -23,6 +23,7 @@ variable "system_timezone" {
 variable "disk_size" {
   type = string
   default = "25G"
+  description = "Logical size of the disk; the physical size will be less thanks to qcow. Must be greater or equal than 24G"
 }
 
 #


### PR DESCRIPTION
**Context**

The root logical volume was "growned" to fill any available space left after the default layout was applied. For example, the default layout uses 22G but the default disk size (see `disk_size` Packer variable) is 25G, so 2 extra gigs were added to root.

For a server usage, root is not necessarily where disk space is required. The default of 10G for root should accommodate most use-cases (in the context of this project)

**Summary of changes**

- `/home` and `/var/` now defaults to 4G
- the root logical volume defaults to 10G and no longer fills any available space
- Any available disk space is left unused by the default allocation and is available for later `lvextend`